### PR TITLE
Fix link for Lisa and Cassie HW pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Syllabus for ITP Foundation Course Introduction to Computational Media: Code
 * 7 -- Final Project Presentations
 
 ## Section Info
-* [Lisa](sections/01_Lisa.md) | [Homework](https://github.com/shiffman/ICM-2019-Code/wiki/Homework-Lisa)
+* [Lisa](sections/01_Lisa.md) | [Homework](https://github.com/ITPNYU/ICM-2019-Code/wiki/Homework-Lisa)
 * [Allison](sections/02_Allison.md) | [Class outlines and homework assignments](https://github.com/ITPNYU/ICM-2019-Code/wiki/Homework-Allison)
 * [Mimi Y.](sections/03_MimiY.md) | [Homework](https://github.com/ITPNYU/ICM-2019-Media/wiki/Homework-MimiY-03)
 * [Mimi Y.](sections/04_MimiY.md) | [Homework](https://github.com/ITPNYU/ICM-2019-Media/wiki/Homework-MimiY-04)
 * [Dano](sections/05_Dano.md) | [Homework](https://github.com/ITPNYU/ICM-2019-Code/wiki/Homework-Dano)
-* [Cassie](sections/06_Cassie.md) | [Homework](https://github.com/shiffman/ICM-2019-Code/wiki/Homework-Cassie)
+* [Cassie](sections/06_Cassie.md) | [Homework](https://github.com/ITPNYU/ICM-2019-Code/wiki/Homework-Cassie)
 
 ## Questions and Discussion
 - [Sign up for the ICM google group](https://groups.google.com/a/itp.nyu.edu/group/icm/)


### PR DESCRIPTION
HW links for Lisa and Cassie were going to Shiffman github rather than ITPNYU.