### PR TITLE
Fix typo in course description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ICM-2019-Media
-Syllabus for ITP Foundation Course Introduction to Computational Media: Code
+Syllabus for ITP Foundation Course Introduction to Computational Media: Media
 
 ## Syllabus Overview
 * 1 -- [Pixels](weeks/01_pixels.md)


### PR DESCRIPTION
I noticed that there's a slight mistake on the course description. I was confused for a minute 😅 